### PR TITLE
Fix Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,11 @@
 {
   "cleanUrls": true,
   "trailingSlash": false,
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/.*", "dest": "/index.html" }
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary
- replace the deprecated `routes` block with a SPA rewrite so the Vercel deployment no longer conflicts with the headers/clean URL settings

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd11fd1b20832ba39e2b5ec99092dc